### PR TITLE
Allow relative dir objects that respond to to_path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+Gemfile.lock
+*.o
+*.so
+*.def
+*.log
+Makefile

--- a/ext/win32/xpath.c
+++ b/ext/win32/xpath.c
@@ -205,8 +205,12 @@ static VALUE rb_xpath(int argc, VALUE* argv, VALUE self){
 
   SafeStringValue(v_path_orig);
 
-  if (!NIL_P(v_dir_orig))
+  if (!NIL_P(v_dir_orig)){
+    if (rb_respond_to(v_dir_orig, rb_intern("to_path")))
+      v_dir_orig = rb_funcall2(v_dir_orig, rb_intern("to_path"), 0, NULL);
+
     SafeStringValue(v_dir_orig);
+  }
 
   // Dup and prep string for modification
   path_encoding = rb_enc_get(v_path_orig);

--- a/test/test_win32_xpath.rb
+++ b/test/test_win32_xpath.rb
@@ -92,6 +92,7 @@ class Test_XPath < Test::Unit::TestCase
   end
 
   test "returns tainted strings or not" do
+    omit_if(RUBY_VERSION.to_f >= 2.7, "skipping taint checks on Ruby 2.7+")
     assert_true(File.expand_path('foo').tainted?)
     assert_true(File.expand_path('foo'.taint).tainted?)
     assert_true(File.expand_path('/foo').tainted?)

--- a/test/test_win32_xpath.rb
+++ b/test/test_win32_xpath.rb
@@ -180,10 +180,16 @@ class Test_XPath < Test::Unit::TestCase
     assert_equal("./a/b/../c", str)
   end
 
-  test "accepts objects that have a to_path method" do
+  test "accepts objects that have a to_path method for main argument" do
     klass = Class.new{ def to_path; "a/b/c"; end }
     obj = klass.new
     assert_equal("#{@pwd}/a/b/c", File.expand_path(obj))
+  end
+
+  test "accepts objects that have a to_path method for relative dir argument" do
+    klass = Class.new{ def to_path; "bar"; end }
+    obj = klass.new
+    assert_equal("#{@pwd}/bar/foo", File.expand_path('foo', obj))
   end
 
   test "works with unicode characters" do


### PR DESCRIPTION
Currently only the first argument accepts objects with a `to_path` method. This PR updates the code so that the relative directory argument (2nd argument) also accepts objects with a `to_path` method.

I also added a .gitignore file and updated a couple tests.