### PR TITLE
Fix error string handling

### DIFF
--- a/ext/win32/xpath.c
+++ b/ext/win32/xpath.c
@@ -64,7 +64,7 @@ wchar_t* find_user(wchar_t* str){
       rb_raise_syserr("WideCharToMultiByte", GetLastError());
     }
 
-    rb_raise(rb_eArgError, "can't find user '%ls'", mstr);
+    rb_raise(rb_eArgError, "can't find user '%s'", mstr);
   }
 
   ruby_xfree(dom); // Don't need this any more

--- a/ext/win32/xpath.c
+++ b/ext/win32/xpath.c
@@ -85,7 +85,7 @@ wchar_t* find_user(wchar_t* str){
   rv = RegOpenKeyExW(HKEY_LOCAL_MACHINE, subkey, 0, KEY_QUERY_VALUE, &phkResult);
 
   if (rv != ERROR_SUCCESS)
-    rb_raise_syserr("RegOpenKeyEx", GetLastError());
+    rb_raise_syserr("RegOpenKeyEx", rv);
 
   lpData = (wchar_t*)malloc(MAX_WPATH);
   cbData = MAX_WPATH;

--- a/ext/win32/xpath.c
+++ b/ext/win32/xpath.c
@@ -49,9 +49,22 @@ wchar_t* find_user(wchar_t* str){
 
   // Get the user's SID
   if (!LookupAccountNameW(NULL, str, sid, &cbSid, dom, &cbDom, &peUse)){
+    char* mstr;
+    DWORD length;
+
     ruby_xfree(sid);
     ruby_xfree(dom);
-    rb_raise(rb_eArgError, "can't find user %ls", str);
+
+    length = WideCharToMultiByte(CP_UTF8, 0, str, -1, NULL, 0, NULL, NULL);
+    mstr = (char*)ruby_xmalloc(length);
+    length = WideCharToMultiByte(CP_UTF8, 0, str, -1, mstr, length, NULL, NULL);
+
+    if (!length){
+      ruby_xfree(str);
+      rb_raise_syserr("WideCharToMultiByte", GetLastError());
+    }
+
+    rb_raise(rb_eArgError, "can't find user '%ls'", mstr);
   }
 
   ruby_xfree(dom); // Don't need this any more

--- a/spec/win32_xpath_spec.rb
+++ b/spec/win32_xpath_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'win32-xpath' do
     @pwd = Dir.pwd
     @tmp = 'C:/Temp'
     @root =  'C:/'
-    @drive = env['HOMEDRIVE']
+    @drive = Dir.home[0,2]
     @home = env['HOME'].tr('\\', '/')
     @unc = "//foo/bar"
     ENV['HOME'] = env['USERPROFILE'] || Dir.home

--- a/spec/win32_xpath_spec.rb
+++ b/spec/win32_xpath_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'win32-xpath' do
     @pwd = Dir.pwd
     @tmp = 'C:/Temp'
     @root =  'C:/'
-    @drive = Dir.home[0,2]
+    @drive = Dir.pwd[0,2]
     @home = env['HOME'].tr('\\', '/')
     @unc = "//foo/bar"
     ENV['HOME'] = env['USERPROFILE'] || Dir.home

--- a/spec/win32_xpath_spec.rb
+++ b/spec/win32_xpath_spec.rb
@@ -162,6 +162,10 @@ RSpec.describe 'win32-xpath' do
     expect{ File.expand_path('~anything') }.to raise_error(ArgumentError, "can't find user 'anything'")
   end
 
+  example "raises an ArgumentError if the account exists but does not have a home directory" do
+    expect{ File.expand_path('~Guest') }.to raise_error(Errno::ENOENT)
+  end
+
   example "converts a tilde plus username as expected" do
     expect(File.expand_path("~#{login}")).to eq("C:/Users/#{login}")
     expect(File.expand_path("~#{login}/foo")).to eq("C:/Users/#{login}/foo")

--- a/spec/win32_xpath_spec.rb
+++ b/spec/win32_xpath_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe 'win32-xpath' do
   end
 
   example "raises an ArgumentError if a bogus username is supplied" do
-    expect{ File.expand_path('~anything') }.to raise_error(ArgumentError)
+    expect{ File.expand_path('~anything') }.to raise_error(ArgumentError, "can't find user 'anything'")
   end
 
   example "converts a tilde plus username as expected" do


### PR DESCRIPTION
This fixes two minor bugs, the first one was where an error string was getting chopped off:

https://github.com/djberg96/win32-xpath/issues

The other was a minor bug in the error code being returned from the `RegOpenKeyEx` function. Instead of using `GetLastError` (which isn't set in this case), use the returned value from the function.

I updated a couple specs as well.