### PR TITLE
Free char* if WideCharToMultiByte fails

### DIFF
--- a/ext/win32/xpath.c
+++ b/ext/win32/xpath.c
@@ -61,6 +61,7 @@ wchar_t* find_user(wchar_t* str){
 
     if (!length){
       ruby_xfree(str);
+      ruby_xfree(mstr);
       rb_raise_syserr("WideCharToMultiByte", GetLastError());
     }
 


### PR DESCRIPTION
Looks like I forgot to explicitly free a char* on a failure condition.