### PR TITLE
Update benchmarks, other minor bits

### DIFF
--- a/bench/bench_win32_xpath.rb
+++ b/bench/bench_win32_xpath.rb
@@ -34,6 +34,11 @@ Benchmark.bm(30) do |x|
     MAX.times{ File.expand_path(str) }
   end
 
+  x.report("expand_path('.')") do
+    str = "."
+    MAX.times{ File.expand_path(str) }
+  end
+
   x.report("expand_path('', '~')") do
     MAX.times{ File.expand_path('', '~') }
   end
@@ -70,6 +75,11 @@ Benchmark.bm(30) do |x|
 
   x.report("expand_path('')") do
     str = ""
+    MAX.times{ File.expand_path(str) }
+  end
+
+  x.report("expand_path('.')") do
+    str = "."
     MAX.times{ File.expand_path(str) }
   end
 

--- a/ext/win32/xpath.c
+++ b/ext/win32/xpath.c
@@ -130,7 +130,7 @@ wchar_t* expand_tilde(){
   // If that isn't found then try USERPROFILE
   if(!size){
     env = L"USERPROFILE"; 
-    size = GetEnvironmentVariableW(env, home, 0);
+    size = GetEnvironmentVariableW(env, NULL, 0);
   }
 
   // If that isn't found the try HOMEDRIVE + HOMEPATH

--- a/ext/win32/xpath.c
+++ b/ext/win32/xpath.c
@@ -231,6 +231,12 @@ static VALUE rb_xpath(int argc, VALUE* argv, VALUE self){
     SafeStringValue(v_dir_orig);
   }
 
+  // Short circuit an empty first argument if there's no second argument.
+  if(NUM2LONG(rb_str_length(v_path_orig)) == 0){
+    if(NIL_P(v_dir_orig))
+      return rb_dir_getwd();
+  }
+
   // Dup and prep string for modification
   path_encoding = rb_enc_get(v_path_orig);
 
@@ -399,6 +405,8 @@ static VALUE rb_xpath(int argc, VALUE* argv, VALUE self){
       length = WideCharToMultiByte(CP_UTF8, 0, wpwd, -1, NULL, 0, NULL, NULL);
       pwd = (char*)ruby_xmalloc(length);
       length = WideCharToMultiByte(CP_UTF8, 0, wpwd, -1, pwd, length, NULL, NULL);
+
+      ruby_xfree(wpwd);
 
       if (!length){
         ruby_xfree(pwd);


### PR DESCRIPTION
This adds benchmarks for the '.' case.

I also short circuit the case where an empty string is provided (without a 2nd argument), and explicitly free some memory for one variable.