### PR TITLE
Free home variable on error

### DIFF
--- a/ext/win32/xpath.c
+++ b/ext/win32/xpath.c
@@ -191,8 +191,10 @@ wchar_t* expand_tilde(){
   while(wcsstr(home, L"/"))
     home[wcscspn(home, L"/")] = L'\\';
 
-  if (PathIsRelativeW(home))
+  if (PathIsRelativeW(home)) {
+    ruby_xfree(home);
     rb_raise(rb_eArgError, "non-absolute home");
+  }
 
   return home;
 }

--- a/ext/win32/xpath.c
+++ b/ext/win32/xpath.c
@@ -176,6 +176,8 @@ wchar_t* expand_tilde(){
       ruby_xfree(temp);
       rb_raise_syserr("PathAppend", GetLastError());
     }
+
+    ruby_xfree(temp);
 #endif
   }
   else{


### PR DESCRIPTION
Free some allocated memory before raising error.